### PR TITLE
removing single digit check 

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -3190,7 +3190,7 @@ void parse_arg(int key, char *arg)
 			char * pch = strtok (arg,",");
 			opt_n_threads = 0;
 			while (pch != NULL && opt_n_threads < MAX_GPUS) {
-				if (pch[0] >= '0' && pch[0] <= '9' && pch[1] == '\0')
+				if (pch[0] >= '0' && pch[0] <= '9')
 				{
 					if (atoi(pch) < ngpus)
 						device_map[opt_n_threads++] = atoi(pch);


### PR DESCRIPTION
which reduces the -d option to only cuda device from 0 to 9.

Its actually the same change which was done as a bug fix from KlausT