### PR TITLE
Changes to get ccminer to compile under Ubuntu 18.04

### DIFF
--- a/bignum.cpp
+++ b/bignum.cpp
@@ -5,7 +5,13 @@
 #include <stdio.h>
 
 #include "uint256.h"
+
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#include "compat/bignum_ssl10.hpp"
+#else
 #include "bignum.hpp"
+#endif
 
 #include "miner.h" // hex2bin
 

--- a/bignum_ssl10.hpp
+++ b/bignum_ssl10.hpp
@@ -9,12 +9,19 @@
 #define PROTOCOL_VERSION 70001
 #endif
 
+#include <map>
+#include <limits>
+#include <algorithm>
 #include <stdexcept>
 #include <vector>
+
+#include "uint256.h"
 
 #include <openssl/bn.h>
 
 #include "serialize.hpp"
+
+using namespace std;
 
 /** Errors thrown by the bignum class */
 class bignum_error : public std::runtime_error
@@ -53,90 +60,75 @@ public:
 
 
 /** C++ wrapper for BIGNUM (OpenSSL bignum) */
-class CBigNum
+class CBigNum : public BIGNUM
 {
-private:
-    BIGNUM *self = NULL;
-
-    void init()
-    {
-        if (self)
-            BN_clear_free(self);
-        self = BN_new();
-        if (!self)
-            throw bignum_error("CBigNum::init(): BN_new() returned NULL");
-    }
-
 public:
-    BIGNUM *get() { return self; }
-    const BIGNUM *getc() const { return self; }
-
     CBigNum()
     {
-        init();
+        BN_init(this);
     }
 
     CBigNum(const CBigNum& b)
     {
-        init();
-        if (!BN_copy(self, b.getc()))
+        BN_init(this);
+        if (!BN_copy(this, &b))
         {
-            BN_clear_free(self);
+            BN_clear_free(this);
             throw bignum_error("CBigNum::CBigNum(const CBigNum&) : BN_copy failed");
         }
     }
 
     CBigNum& operator=(const CBigNum& b)
     {
-        if (!BN_copy(self, b.getc()))
+        if (!BN_copy(this, &b))
             throw bignum_error("CBigNum::operator= : BN_copy failed");
         return (*this);
     }
 
     ~CBigNum()
     {
-        BN_clear_free(self);
+        BN_clear_free(this);
     }
 
     //CBigNum(char n) is not portable.  Use 'signed char' or 'unsigned char'.
-    CBigNum(signed char n)      { init(); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(short n)            { init(); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(int n)              { init(); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(long n)             { init(); if (n >= 0) setulong(n); else setint64(n); }
-    CBigNum(int64 n)            { init(); setint64(n); }
-    CBigNum(unsigned char n)    { init(); setulong(n); }
-    CBigNum(unsigned short n)   { init(); setulong(n); }
-    CBigNum(unsigned int n)     { init(); setulong(n); }
-    CBigNum(unsigned long n)    { init(); setulong(n); }
-    CBigNum(uint64 n)           { init(); setuint64(n); }
-    explicit CBigNum(uint256 n) { init(); setuint256(n); }
+    CBigNum(signed char n)      { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(short n)            { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(int n)              { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(long n)             { BN_init(this); if (n >= 0) setulong(n); else setint64(n); }
+    CBigNum(int64 n)            { BN_init(this); setint64(n); }
+    CBigNum(unsigned char n)    { BN_init(this); setulong(n); }
+    CBigNum(unsigned short n)   { BN_init(this); setulong(n); }
+    CBigNum(unsigned int n)     { BN_init(this); setulong(n); }
+    CBigNum(unsigned long n)    { BN_init(this); setulong(n); }
+    CBigNum(uint64 n)           { BN_init(this); setuint64(n); }
+    explicit CBigNum(uint256 n) { BN_init(this); setuint256(n); }
 
     explicit CBigNum(const std::vector<unsigned char>& vch)
     {
-        init();
+        BN_init(this);
         setvch(vch);
     }
 
     void setulong(unsigned long n)
     {
-        if (!BN_set_word(self, n))
+        if (!BN_set_word(this, n))
             throw bignum_error("CBigNum conversion from unsigned long : BN_set_word failed");
     }
 
     unsigned long getulong() const
     {
-        return BN_get_word(self);
+        return (unsigned long) BN_get_word(this);
     }
 
     unsigned int getuint() const
     {
-        return BN_get_word(self);
+        return (unsigned int) BN_get_word(this);
     }
 
     int getint() const
     {
-        unsigned long n = BN_get_word(self);
-        if (!BN_is_negative(self))
+        unsigned long n = (unsigned long) BN_get_word(this);
+        if (!BN_is_negative(this))
             return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::max() : n);
         else
             return (n > (unsigned long)std::numeric_limits<int>::max() ? std::numeric_limits<int>::min() : -(int)n);
@@ -149,9 +141,11 @@ public:
         bool fNegative;
         uint64 n;
 
-        if (sn < (int64)0)
+        if (sn < 0LL)
         {
-            // Since the minimum signed integer cannot be represented as positive so long as its type is signed, and it's not well-defined what happens if you make it unsigned before negating it, we instead increment the negative integer by 1, convert it, then increment the (now positive) unsigned integer by 1 to compensate
+            // Since the minimum signed integer cannot be represented as positive so long as its type is signed,
+            // and it's not well-defined what happens if you make it unsigned before negating it,
+            // we instead increment the negative integer by 1, convert it, then increment the (now positive) unsigned integer by 1 to compensate
             n = -(sn + 1);
             ++n;
             fNegative = true;
@@ -177,27 +171,12 @@ public:
             }
             *p++ = c;
         }
-        unsigned int nSize = p - (pch + 4);
+        unsigned int nSize = (unsigned int) (p - (pch + 4));
         pch[0] = (nSize >> 24) & 0xff;
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize) & 0xff;
-        BN_mpi2bn(pch, p - pch, self);
-    }
-
-    uint64 getuint64()
-    {
-        unsigned int nSize = BN_bn2mpi(self, NULL);
-        if (nSize < 4)
-            return 0;
-        std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(self, &vch[0]);
-        if (vch.size() > 4)
-            vch[4] &= 0x7f;
-        uint64 n = 0;
-        for (unsigned int i = 0, j = vch.size()-1; i < sizeof(n) && j >= 4; i++, j--)
-            ((unsigned char*)&n)[i] = vch[j];
-        return n;
+        BN_mpi2bn(pch, (int) (p - pch), this);
     }
 
     void setuint64(uint64 n)
@@ -219,12 +198,12 @@ public:
             }
             *p++ = c;
         }
-        unsigned int nSize = p - (pch + 4);
+        unsigned int nSize = (unsigned int) (p - (pch + 4));
         pch[0] = (nSize >> 24) & 0xff;
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize) & 0xff;
-        BN_mpi2bn(pch, p - pch, self);
+        BN_mpi2bn(pch, (int) (p - pch), this);
     }
 
     void setuint256(uint256 n)
@@ -247,34 +226,33 @@ public:
             }
             *p++ = c;
         }
-        unsigned int nSize = p - (pch + 4);
+        unsigned int nSize = (unsigned int) (p - (pch + 4));
         pch[0] = (nSize >> 24) & 0xff;
         pch[1] = (nSize >> 16) & 0xff;
         pch[2] = (nSize >> 8) & 0xff;
         pch[3] = (nSize >> 0) & 0xff;
-        BN_mpi2bn(pch, p - pch, self);
+        BN_mpi2bn(pch, (int) (p - pch), this);
     }
 
-    uint256 getuint256()
+    uint256 getuint256() const
     {
-        unsigned int nSize = BN_bn2mpi(self, NULL);
+        unsigned int nSize = BN_bn2mpi(this, NULL);
         if (nSize < 4)
             return 0;
         std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(self, &vch[0]);
+        BN_bn2mpi(this, &vch[0]);
         if (vch.size() > 4)
             vch[4] &= 0x7f;
         uint256 n = 0;
-        for (unsigned int i = 0, j = vch.size()-1; i < sizeof(n) && j >= 4; i++, j--)
+        for (unsigned int i = 0, j = (unsigned int) vch.size()-1; i < sizeof(n) && j >= 4; i++, j--)
             ((unsigned char*)&n)[i] = vch[j];
         return n;
     }
 
-
     void setvch(const std::vector<unsigned char>& vch)
     {
         std::vector<unsigned char> vch2(vch.size() + 4);
-        unsigned int nSize = vch.size();
+        unsigned int nSize = (unsigned int) vch.size();
         // BIGNUM's byte stream format expects 4 bytes of
         // big endian size data info at the front
         vch2[0] = (nSize >> 24) & 0xff;
@@ -283,43 +261,83 @@ public:
         vch2[3] = (nSize >> 0) & 0xff;
         // swap data to big endian
         reverse_copy(vch.begin(), vch.end(), vch2.begin() + 4);
-        BN_mpi2bn(&vch2[0], vch2.size(), self);
+        BN_mpi2bn(&vch2[0], (int) vch2.size(), this);
     }
 
     std::vector<unsigned char> getvch() const
     {
-        unsigned int nSize = BN_bn2mpi(self, NULL);
+        unsigned int nSize = BN_bn2mpi(this, NULL);
         if (nSize <= 4)
             return std::vector<unsigned char>();
         std::vector<unsigned char> vch(nSize);
-        BN_bn2mpi(self, &vch[0]);
+        BN_bn2mpi(this, &vch[0]);
         vch.erase(vch.begin(), vch.begin() + 4);
         reverse(vch.begin(), vch.end());
         return vch;
     }
 
+    // The "compact" format is a representation of a whole
+    // number N using an unsigned 32bit number similar to a
+    // floating point format.
+    // The most significant 8 bits are the unsigned exponent of base 256.
+    // This exponent can be thought of as "number of bytes of N".
+    // The lower 23 bits are the mantissa.
+    // Bit number 24 (0x800000) represents the sign of N.
+    // N = (-1^sign) * mantissa * 256^(exponent-3)
+    //
+    // Satoshi's original implementation used BN_bn2mpi() and BN_mpi2bn().
+    // MPI uses the most significant bit of the first byte as sign.
+    // Thus 0x1234560000 is compact (0x05123456)
+    // and  0xc0de000000 is compact (0x0600c0de)
+    // (0x05c0de00) would be -0x40de000000
+    //
+    // Bitcoin only uses this "compact" format for encoding difficulty
+    // targets, which are unsigned 256bit quantities.  Thus, all the
+    // complexities of the sign bit and using base 256 are probably an
+    // implementation accident.
+    //
+    // This implementation directly uses shifts instead of going
+    // through an intermediate MPI representation.
     CBigNum& SetCompact(unsigned int nCompact)
     {
         unsigned int nSize = nCompact >> 24;
-        std::vector<unsigned char> vch(4 + nSize);
-        vch[3] = nSize;
-        if (nSize >= 1) vch[4] = (nCompact >> 16) & 0xff;
-        if (nSize >= 2) vch[5] = (nCompact >> 8) & 0xff;
-        if (nSize >= 3) vch[6] = (nCompact >> 0) & 0xff;
-        BN_mpi2bn(&vch[0], vch.size(), self);
+        bool fNegative     =(nCompact & 0x00800000) != 0;
+        unsigned int nWord = nCompact & 0x007fffff;
+        if (nSize <= 3)
+        {
+            nWord >>= 8*(3-nSize);
+            BN_set_word(this, nWord);
+        }
+        else
+        {
+            BN_set_word(this, nWord);
+            BN_lshift(this, this, 8*(nSize-3));
+        }
+        BN_set_negative(this, fNegative);
         return *this;
     }
 
     unsigned int GetCompact() const
     {
-        unsigned int nSize = BN_bn2mpi(self, NULL);
-        std::vector<unsigned char> vch(nSize);
-        nSize -= 4;
-        BN_bn2mpi(self, &vch[0]);
-        unsigned int nCompact = nSize << 24;
-        if (nSize >= 1) nCompact |= (vch[4] << 16);
-        if (nSize >= 2) nCompact |= (vch[5] << 8);
-        if (nSize >= 3) nCompact |= (vch[6] << 0);
+        unsigned int nSize = BN_num_bytes(this);
+        unsigned int nCompact = 0;
+        if (nSize <= 3)
+            nCompact = (unsigned int) BN_get_word(this) << 8*(3-nSize);
+        else
+        {
+            CBigNum bn;
+            BN_rshift(&bn, this, 8*(nSize-3));
+            nCompact = (unsigned int) BN_get_word(&bn);
+        }
+        // The 0x00800000 bit denotes the sign.
+        // Thus, if it is already set, divide the mantissa by 256 and increase the exponent.
+        if (nCompact & 0x00800000)
+        {
+            nCompact >>= 8;
+            nSize++;
+        }
+        nCompact |= nSize << 24;
+        nCompact |= (BN_is_negative(this) ? 0x00800000 : 0);
         return nCompact;
     }
 
@@ -360,20 +378,20 @@ public:
         CBigNum bn0 = 0;
         std::string str;
         CBigNum bn = *this;
-        BN_set_negative(bn.get(), false);
+        BN_set_negative(&bn, false);
         CBigNum dv;
         CBigNum rem;
-        if (BN_cmp(bn.getc(), bn0.getc()) == 0)
+        if (BN_cmp(&bn, &bn0) == 0)
             return "0";
-        while (BN_cmp(bn.getc(), bn0.getc()) > 0)
+        while (BN_cmp(&bn, &bn0) > 0)
         {
-            if (!BN_div(dv.get(), rem.get(), bn.getc(), bnBase.getc(), pctx))
+            if (!BN_div(&dv, &rem, &bn, &bnBase, pctx))
                 throw bignum_error("CBigNum::ToString() : BN_div failed");
             bn = dv;
             unsigned int c = rem.getulong();
             str += "0123456789abcdef"[c];
         }
-        if (BN_is_negative(self))
+        if (BN_is_negative(this))
             str += "-";
         reverse(str.begin(), str.end());
         return str;
@@ -406,12 +424,12 @@ public:
 
     bool operator!() const
     {
-        return BN_is_zero(self);
+        return BN_is_zero(this);
     }
 
     CBigNum& operator+=(const CBigNum& b)
     {
-        if (!BN_add(self, self, b.getc()))
+        if (!BN_add(this, this, &b))
             throw bignum_error("CBigNum::operator+= : BN_add failed");
         return *this;
     }
@@ -425,7 +443,7 @@ public:
     CBigNum& operator*=(const CBigNum& b)
     {
         CAutoBN_CTX pctx;
-        if (!BN_mul(self, self, b.getc(), pctx))
+        if (!BN_mul(this, this, &b, pctx))
             throw bignum_error("CBigNum::operator*= : BN_mul failed");
         return *this;
     }
@@ -444,7 +462,7 @@ public:
 
     CBigNum& operator<<=(unsigned int shift)
     {
-        if (!BN_lshift(self, self, shift))
+        if (!BN_lshift(this, this, shift))
             throw bignum_error("CBigNum:operator<<= : BN_lshift failed");
         return *this;
     }
@@ -455,13 +473,13 @@ public:
         //   if built on ubuntu 9.04 or 9.10, probably depends on version of OpenSSL
         CBigNum a = 1;
         a <<= shift;
-        if (BN_cmp(a.getc(), self) > 0)
+        if (BN_cmp(&a, this) > 0)
         {
             *this = 0;
             return *this;
         }
 
-        if (!BN_rshift(self, self, shift))
+        if (!BN_rshift(this, this, shift))
             throw bignum_error("CBigNum:operator>>= : BN_rshift failed");
         return *this;
     }
@@ -470,7 +488,7 @@ public:
     CBigNum& operator++()
     {
         // prefix operator
-        if (!BN_add(self, self, BN_value_one()))
+        if (!BN_add(this, this, BN_value_one()))
             throw bignum_error("CBigNum::operator++ : BN_add failed");
         return *this;
     }
@@ -487,7 +505,7 @@ public:
     {
         // prefix operator
         CBigNum r;
-        if (!BN_sub(r.get(), self, BN_value_one()))
+        if (!BN_sub(&r, this, BN_value_one()))
             throw bignum_error("CBigNum::operator-- : BN_sub failed");
         *this = r;
         return *this;
@@ -512,7 +530,7 @@ public:
 inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
-    if (!BN_add(r.get(), a.getc(), b.getc()))
+    if (!BN_add(&r, &a, &b))
         throw bignum_error("CBigNum::operator+ : BN_add failed");
     return r;
 }
@@ -520,7 +538,7 @@ inline const CBigNum operator+(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator-(const CBigNum& a, const CBigNum& b)
 {
     CBigNum r;
-    if (!BN_sub(r.get(), a.getc(), b.getc()))
+    if (!BN_sub(&r, &a, &b))
         throw bignum_error("CBigNum::operator- : BN_sub failed");
     return r;
 }
@@ -528,7 +546,7 @@ inline const CBigNum operator-(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator-(const CBigNum& a)
 {
     CBigNum r(a);
-    BN_set_negative(r.get(), !BN_is_negative(r.getc()));
+    BN_set_negative(&r, !BN_is_negative(&r));
     return r;
 }
 
@@ -536,7 +554,7 @@ inline const CBigNum operator*(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_mul(r.get(), a.getc(), b.getc(), pctx))
+    if (!BN_mul(&r, &a, &b, pctx))
         throw bignum_error("CBigNum::operator* : BN_mul failed");
     return r;
 }
@@ -545,7 +563,7 @@ inline const CBigNum operator/(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_div(r.get(), NULL, a.getc(), b.getc(), pctx))
+    if (!BN_div(&r, NULL, &a, &b, pctx))
         throw bignum_error("CBigNum::operator/ : BN_div failed");
     return r;
 }
@@ -554,7 +572,7 @@ inline const CBigNum operator%(const CBigNum& a, const CBigNum& b)
 {
     CAutoBN_CTX pctx;
     CBigNum r;
-    if (!BN_mod(r.get(), a.getc(), b.getc(), pctx))
+    if (!BN_mod(&r, &a, &b, pctx))
         throw bignum_error("CBigNum::operator% : BN_div failed");
     return r;
 }
@@ -562,7 +580,7 @@ inline const CBigNum operator%(const CBigNum& a, const CBigNum& b)
 inline const CBigNum operator<<(const CBigNum& a, unsigned int shift)
 {
     CBigNum r;
-    if (!BN_lshift(r.get(), a.getc(), shift))
+    if (!BN_lshift(&r, &a, shift))
         throw bignum_error("CBigNum:operator<< : BN_lshift failed");
     return r;
 }
@@ -574,11 +592,11 @@ inline const CBigNum operator>>(const CBigNum& a, unsigned int shift)
     return r;
 }
 
-inline bool operator==(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.getc(), b.getc()) == 0); }
-inline bool operator!=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.getc(), b.getc()) != 0); }
-inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.getc(), b.getc()) <= 0); }
-inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(a.getc(), b.getc()) >= 0); }
-inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(a.getc(), b.getc()) < 0); }
-inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(a.getc(), b.getc()) > 0); }
+inline bool operator==(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) == 0); }
+inline bool operator!=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) != 0); }
+inline bool operator<=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) <= 0); }
+inline bool operator>=(const CBigNum& a, const CBigNum& b) { return (BN_cmp(&a, &b) >= 0); }
+inline bool operator<(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) < 0); }
+inline bool operator>(const CBigNum& a, const CBigNum& b)  { return (BN_cmp(&a, &b) > 0); }
 
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ AC_CHECK_LIB([pthread], [pthread_create], PTHREAD_LIBS="-lpthread",
 ))))
 
 AC_CHECK_LIB([z],[gzopen], [], [])
-AC_CHECK_LIB([ssl],[SSL_library_init], [], [AC_MSG_ERROR([OpenSSL library required])])
+AC_CHECK_LIB([ssl],[SSL_free], [], [AC_MSG_ERROR([OpenSSL library required])])
 AC_CHECK_LIB([crypto],[EVP_DigestFinal_ex], [], [AC_MSG_ERROR([OpenSSL library required])])
 
 # libpci-dev (to get vendor name)


### PR DESCRIPTION
Ubuntu 18.04 has openssl 1.1 by default. 

I've pulled in two of the patches from https://github.com/tpruvot/ccminer to allow support for openssl 1.1 and the changes needed in the bignum class for openssl 1.1. It now compiles under Ubuntu 18.04 and appears to work fine. I haven't noticed any change in the hash rate as a result of these patches. 
    
These patches are:
    * b54be47 (tag: 2.2.4-tpruvot) upgrade BIGNUM class for openssl 1.1
    * bfa616a linux: common openssl lib function for 1.1+

I haven't tested compiling it under Windows as I don't have a Windows box available.

Thanks
